### PR TITLE
fix encode_set_command struct packing

### DIFF
--- a/fridge.py
+++ b/fridge.py
@@ -247,7 +247,7 @@ def encode_set_command(data: FridgeData) -> bytes:
     # pylint: disable=no-else-return
     if data.unit2 is None:
         return create_packet(struct.pack(
-            '>??BBbbbbBBbbbb',
+            '>B??BBbbbbBBbbbb',
             FridgeCommand.Set,
             data.controls_locked, data.powered_on, data.run_mode, data.battery_saver,
             data.unit1.target_temperature, data.max_selectable_temperature,
@@ -258,7 +258,7 @@ def encode_set_command(data: FridgeData) -> bytes:
         ))
     else:
         return create_packet(struct.pack(
-            '>??BBbbbbBBbbbbbxxbbbbbxxx',
+            '>B??BBbbbbBBbbbbbxxbbbbbxxx',
             FridgeCommand.Set,
             data.controls_locked, data.powered_on, data.run_mode, data.battery_saver,
             data.unit1.target_temperature, data.max_selectable_temperature,


### PR DESCRIPTION
the struct packing blows up because the format string misses the `B` that encodes the command integer.

the error was `struct.error: pack expected 20 items for packing (got 21)`

I'm not a python person so I'm not sure if I need to provide any additional info for this. having said that, applying this patch enables me to run the .set() method on Fridge against a `pluginfestivals icecube duo`

I stumbled upon your repo when I did research around my fridge.. Nice work on documenting the data for the gatt commands! I tried reversing the app of my fridge but failed getting anything conclusive. Your repo helped me immensely understanding the bluetoothdump I created from running the app!